### PR TITLE
Empty action returns prompt

### DIFF
--- a/core/shell.py
+++ b/core/shell.py
@@ -54,6 +54,8 @@ class Shell(object):
 
     def run_command(self, cmd):
         action = cmd.split(" ")[0].lower()
+        if not action:
+            return
         remap = { 
             "?": "help",
             "exploit": "run",


### PR DESCRIPTION
Sometimes it's a habit to just spam Enter to clear or make more room. Current behavior will print "[-] Unrecognized command, use 'help'." This PR just returns if no action is defined.