### PR TITLE
Job failed status fix + restore reverted change

### DIFF
--- a/core/job.py
+++ b/core/job.py
@@ -52,7 +52,7 @@ class Job(object):
         self.errno = str(errno)
         self.errdesc = errdesc
         self.errname = errname
-        self.status = Job.FAILED
+        self.completed = Job.FAILED
         self.sanitize_data(data)
 
         self.print_error()

--- a/core/session.py
+++ b/core/session.py
@@ -50,7 +50,7 @@ class Session(object):
         if self.os != "" or self.user != "" or self.computer != "" or self.elevated != self.ELEVATED_UNKNOWN:
             return False
 
-        data = data.encode().split("~~~")
+        data = data.decode().split("~~~")
         if len(data) != 4:
             return False
 


### PR DESCRIPTION
If a job fails, it will now properly display so in jobs. Also, restored an accidental revert for python3 compatibility.