### PR TITLE
Shorten prompt state path

### DIFF
--- a/core/colors.py
+++ b/core/colors.py
@@ -43,6 +43,10 @@ class Colors(object):
     def get_prompt(self, state, isreadline = True):
         import os
         glyph = "#" if os.geteuid() == 0 else "$"
+        last = state.split("/")[-1]
+        state = [s[0:3] for s in state.split("/")[:-1]]
+        state.append(last)
+        state = "/".join(state)
         return "%s%s: %s%s" % (self.colorize("(", [self.GREEN], isreadline),
                                  self.colorize("koadic", [self.BOLD], isreadline),
                                  self.colorize(state, [self.CYAN], isreadline),


### PR DESCRIPTION
This PR shortens the state path as displayed in the prompt. Normally, the path looks like this:

`implant/elevate/bypassuac_eventvwr`

But we can shorten this down by doing something like this:

`imp/ele/bypassuac_eventvwr`

And if you've used Koadic for any real length of time, you still know that this is an elevate implant.