### PR TITLE
Improved tab completion on implant options

### DIFF
--- a/core/commands/set.py
+++ b/core/commands/set.py
@@ -7,7 +7,7 @@ def autocomplete(shell, line, text, state):
         return None
 
     env = shell.plugins[shell.state]
-    options = [x.name + " " for x in env.options.options if x.name.startswith(text) and not x.hidden]
+    options = [x.name + " " for x in env.options.options if x.name.upper().startswith(text.upper()) and not x.hidden]
 
     try:
         return options[state]


### PR DESCRIPTION
This PR is a small, but incredibly satisfying quality of life improvement. Tab completion for implant options only worked if you started typing the option name in the same case. Now you can use either case and it will tab complete.