### PR TITLE
Explain how to stage koadic through a portfwd

### DIFF
--- a/core/commands/help.py
+++ b/core/commands/help.py
@@ -47,6 +47,8 @@ def help_all(shell):
     shell.print_plain(formats.format("---------", "-------------"))
 
     for key, env in shell.actions.items():
+        if getattr(env, "hidden_command", False):
+            continue
         shell.print_plain(formats.format(key, env.DESCRIPTION))
 
     shell.print_plain("")

--- a/core/commands/portfwd.py
+++ b/core/commands/portfwd.py
@@ -1,0 +1,25 @@
+DESCRIPTION = "stub command for help text"
+hidden_command = True
+
+def autocomplete(shell, line, text, state):
+    return None
+
+def help(shell):
+    msg = """
+Unlike most connectback RATs, Koadic does not rely on a single long-lived TCP connection. Windows Script Host isn't smart enough to do that. Instead, Koadic uses repeated HTTP requests in separate connections. It is important that you not modify the URL of a listener between when Koadic spits it out and when it is executed on the host because the very first thing Koadic is going to try and do after the first connection is establish a second connection - and it's going to try and make the second connection using the URL Koadic knows about, not the one you executed.
+
+So! How do I use Koadic through a port forward? Easy! Just make Koadic generate the correct URL right out of the gate. Set SRVHOST and SRVPORT to whatever address the target box needs to initiate connections to. It doesn't matter if that's not a local address on the host where Koadic is running. Koadic will just bind 0.0.0.0 and accept connections from anywhere.
+""".strip()
+    try:
+        import textwrap
+        msg2 = ""
+        for paragraph in msg.split("\n\n"):
+            msg2 += "\n".join(textwrap.wrap(paragraph))
+            msg2 += "\n\n"
+        msg = msg2.strip()
+    except:
+        pass
+    shell.print_plain(msg)
+
+def execute(shell, cmd):
+    shell.print_plain("Sorry! This is just a stub-command to explain how to stage Koadic through a port forward. Windows Script Host is not smart enough for Koadic to do its own port forwards. You probably just want to stage a native RAT.");

--- a/core/stager.py
+++ b/core/stager.py
@@ -77,7 +77,7 @@ class Stager(core.plugin.Plugin):
             server.start()
 
             self.shell.print_good("Spawned a stager at %s" % (server.options.get("URL")))
-            self.shell.print_warning("Avoid manually editing this URL!!!")
+            self.shell.print_warning("Don't edit this URL! (See: 'help portfwd')")
             server.print_payload()
         except OSError as e:
             port = str(self.options.get("SRVPORT"))


### PR DESCRIPTION
We put a warning in to help people not hose themselves trying to stage koadic through a portforward wrong, but it would be better to show them how to do it right.

Adds "help portfwd" and changes the warning to tell people to look at "help portfwd"