### PR TITLE
Update Ubuntu base in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    ubuntu:19.10
+FROM    ubuntu:20.04
 WORKDIR /opt/koadic
 RUN     apt-get update && apt-get install -y python3 python3-pip socat 
 COPY    . /opt/koadic


### PR DESCRIPTION
Previous version errored during Docker build. 
```
sudo docker build -t koadic .
Sending build context to Docker daemon  17.32MB
Step 1/6 : FROM    ubuntu:19.10
19.10: Pulling from library/ubuntu
3f2411103a12: Pull complete 
4da04088b2c2: Pull complete 
ab1184837b6f: Pull complete 
354c6da61dcc: Pull complete 
Digest: sha256:f332c4057e21ec71cc8b20b05328d476104a069bfa6882877e0920e8140edcf0
Status: Downloaded newer image for ubuntu:19.10
 ---> 2f6c85efea61
Step 2/6 : WORKDIR /opt/koadic
 ---> Running in b8aeb9675b84
Removing intermediate container b8aeb9675b84
 ---> c44dc7bf691b
Step 3/6 : RUN     apt-get update && apt-get install -y python3 python3-pip socat
 ---> Running in 58a455c3f85f
Ign:1 http://security.ubuntu.com/ubuntu eoan-security InRelease
Ign:2 http://archive.ubuntu.com/ubuntu eoan InRelease
Err:3 http://security.ubuntu.com/ubuntu eoan-security Release
  404  Not Found [IP: 91.189.88.152 80]
Ign:4 http://archive.ubuntu.com/ubuntu eoan-updates InRelease
Ign:5 http://archive.ubuntu.com/ubuntu eoan-backports InRelease
Err:6 http://archive.ubuntu.com/ubuntu eoan Release
  404  Not Found [IP: 91.189.88.152 80]
Err:7 http://archive.ubuntu.com/ubuntu eoan-updates Release
  404  Not Found [IP: 91.189.88.152 80]
Err:8 http://archive.ubuntu.com/ubuntu eoan-backports Release
  404  Not Found [IP: 91.189.88.152 80]
Reading package lists...
E: The repository 'http://security.ubuntu.com/ubuntu eoan-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-backports Release' does not have a Release file.
The command '/bin/sh -c apt-get update && apt-get install -y python3 python3-pip socat' returned a non-zero code: 100
```

Using 20.04 allows build process to complete.